### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/asaduzzamanrahat/f9dd914c-316e-4628-97c1-fd53e15801ef/002a197b-558d-4c85-b83f-853bc4efa6e3/_apis/work/boardbadge/eb5703d6-b497-4161-8035-f0d1da4d42b6)](https://dev.azure.com/asaduzzamanrahat/f9dd914c-316e-4628-97c1-fd53e15801ef/_boards/board/t/002a197b-558d-4c85-b83f-853bc4efa6e3/Microsoft.RequirementCategory)
 # ProjectHermes
 
 A platform for renting personal items to the community 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/asaduzzamanrahat/f9dd914c-316e-4628-97c1-fd53e15801ef/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.